### PR TITLE
Arreglar la sección de contacto y ubicación

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ include("db.php");
 <body>
     <div class="fixer" id="fixer">
         <div class="fixer-content">
-            <p><i class="fas fa-phone"></i> Cel: 3128839301</p>
-            <p><i class="fas fa-map-marker-alt"></i> Dir: Diag 15 #71A-58</p>
+            <p><i class="fas fa-phone"></i> <strong>Celular:</strong> <a href="tel:+573128839301">+57 312 8839301</a></p>
+            <p><i class="fas fa-map-marker-alt"></i> <strong>Dirección:</strong> Diagonal 15 #71A-58, Cali, Colombia</p>
         </div>
     </div>
     


### PR DESCRIPTION
Se actualizaron los detalles de contacto en la página. Los cambios incluyen:

1. **Número de teléfono**: 
   - Se añadió un enlace `tel:` para permitir que los usuarios puedan hacer clic en el número y realizar una llamada directamente desde dispositivos móviles.
   - El texto del teléfono fue modificado para que diga "Celular" en lugar de "Cel".
   
2. **Dirección**: 
   - Se actualizó la dirección de la empresa agregando la ciudad y el país para mayor claridad (Cali, Colombia).
   - Se añadió el término "Dirección" en lugar de "Dir." para una mejor presentación.